### PR TITLE
refactor newtypes: public built-in constructors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,33 +7,15 @@ extern crate newtype_derive;
 
 custom_derive! {
     #[derive(Debug, PartialEq, Clone, PartialOrd, Copy, Default, NewtypeFrom, NewtypeAdd, NewtypeSub, NewtypeMul, NewtypeDiv)]
-    pub struct TimeSecs(f32);
-}
-
-impl TimeSecs {
-    pub fn new(val: f32) -> Self {
-        Self(val)
-    }
+    pub struct TimeSecs(pub f32);
 }
 
 custom_derive! {
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, NewtypeFrom, NewtypeAdd, NewtypeSub, NewtypeMul, NewtypeDiv)]
-    pub struct FrequencyHz(u32);
+    pub struct FrequencyHz(pub u32);
 }
 
-impl FrequencyHz {
-    pub fn new(val: u32) -> Self {
-        Self(val)
-    }
-}
-
-impl From<FrequencyHz> for f32 {
-    fn from(hz: FrequencyHz) -> Self {
-        hz.0 as f32
-    }
-}
-
-pub struct Signal(Box<dyn Fn(TimeSecs) -> f32>);
+pub struct Signal(pub Box<dyn Fn(TimeSecs) -> f32>);
 
 impl Debug for Signal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -67,9 +49,6 @@ impl Signal {
     pub fn at(&self, time: TimeSecs) -> f32 {
         self.0(time)
     }
-    pub fn new(f: Box<dyn Fn(TimeSecs) -> f32>) -> Self {
-        Self(f)
-    }
 }
 
 impl FrequencyHz {
@@ -78,7 +57,7 @@ impl FrequencyHz {
     }
 
     pub fn period(self) -> TimeSecs {
-        TimeSecs::new(1.0) / self.0.into()
+        TimeSecs(1.0) / self.0.into()
     }
 }
 
@@ -107,11 +86,12 @@ pub fn sample(rate: FrequencyHz, s: Signal) -> impl Iterator<Item = f32> {
     })
 }
 
-pub struct Weight(u32);
+// stuff below this line is currently unused
+pub struct Weight(pub u32);
 
 custom_derive! {
     #[derive(Debug, PartialEq, PartialOrd, Clone, Copy, NewtypeAdd, NewtypeSub, NewtypeDiv, NewtypeMul, NewtypeFrom)]
-    pub struct Connection(f32);
+    pub struct Connection(pub f32);
 }
 
 pub fn weighted_sum(ws: Vec<Weight>, cs: Vec<Connection>) -> f32 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 use analogue::*;
-use nannou::{draw::properties::ColorScalar, prelude::*};
+use nannou::prelude::*;
 
 fn main() {
     nannou::sketch(view).run();
 }
 
 fn view(app: &App, frame: Frame) {
-    let t = TimeSecs::new(app.time);
-    let square = square_wave(FrequencyHz::new(1)).scale(100.0);
-    let sine = sine_wave(FrequencyHz::new(1)).scale(100.0);
+    let t = TimeSecs(app.time);
+    let square = square_wave(FrequencyHz(1)).scale(100.0);
+    let sine = sine_wave(FrequencyHz(1)).scale(100.0);
 
     let win = app.window_rect();
     let draw = app.draw();
@@ -17,7 +17,7 @@ fn view(app: &App, frame: Frame) {
     let half = win.w() / 2.0;
     let range = 1..win.w() as u32;
     let time_and_x = range.map(|right| {
-        let time = t + TimeSecs::new(right as f32 / 100.0);
+        let time = t + TimeSecs(right as f32 / 100.0);
         let x = (right as f32) - half;
         (time, x)
     });

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,9 +4,15 @@ mod tests {
     use proptest::prelude::*;
     prop_compose! {
         fn arb_frequency()(n in any::<u32>()) -> FrequencyHz {
-            FrequencyHz::new(n)
+            FrequencyHz(n)
         }
+    }
 
+    prop_compose! {
+        fn arb_signal()(amplitude in any::<f32>()) -> Signal {
+            let f = move |_| amplitude;
+            Signal(Box::new(f))
+        }
     }
 
     fn approx_eq(lhs: f32, rhs: f32) -> bool {
@@ -28,23 +34,23 @@ mod tests {
         // SKIP! failing now, not sure why
         // #[test]
         // fn test_sine_f_n_fth_is_0(freq in arb_frequency(), n in any::<f32>()) {
-        //     prop_assume!(freq > FrequencyHz::new(0));
-        //     let t = freq.period() * TimeSecs::new(n);
+        //     prop_assume!(freq > FrequencyHz(0));
+        //     let t = freq.period() * TimeSecs(n);
         //     let res = sine_wave(freq).at(t);
         //     prop_assert_approx_eq!(res, 0.0);
         // }
 
         #[test]
         fn test_sine_f_1_4th_is_1(freq in arb_frequency()) {
-            prop_assume!(freq > FrequencyHz::new(0));
-            let t = freq.period() * TimeSecs::new(0.25);
+            prop_assume!(freq > FrequencyHz(0));
+            let t = freq.period() * TimeSecs(0.25);
             prop_assert_approx_eq!(sine_wave(freq).at(t), 1.0);
         }
 
         #[test]
         fn test_sine_f_3_4th_is_neg_1(freq in arb_frequency()) {
-            prop_assume!(freq > FrequencyHz::new(0));
-            let t = TimeSecs::new(0.75) * freq.period();
+            prop_assume!(freq > FrequencyHz(0));
+            let t = TimeSecs(0.75) * freq.period();
             prop_assert_approx_eq!(sine_wave(freq).at(t), -1.0);
         }
 


### PR DESCRIPTION
Should be OK to expose implementation for our newtypes, and will
make certain operations easier, such as exponentiation.