### PR TITLE
use Arc for Signal closures

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ fn view(app: &App, frame: Frame) {
     let t = TimeSecs(app.time);
     let square = square_wave(FrequencyHz(1)).scale(100.0);
     let sine = sine_wave(FrequencyHz(1)).scale(100.0);
+    let combined = square.clone() + sine.clone();
 
     let win = app.window_rect();
     let draw = app.draw();
@@ -21,20 +22,15 @@ fn view(app: &App, frame: Frame) {
         let x = (right as f32) - half;
         (time, x)
     });
-    let sine_plot = time_and_x.clone().map(|(time, x)| {
-        let amp = sine.at(time);
-        (pt2(x, amp), BLUE)
-    });
-    let square_plot = time_and_x.clone().map(|(time, x)| {
-        let amp = square.at(time) + 250.0;
-        (pt2(x, amp), WHITE)
-    });
-    let combined_plot = time_and_x.clone().map(|(time, x)| {
-        let amp = ((square.at(time) + sine.at(time)) / 2.0) - 250.0;
-        (pt2(x, amp), GREEN)
-    });
-    draw.polyline().weight(3.0).points_colored(sine_plot);
-    draw.polyline().weight(3.0).points_colored(square_plot);
-    draw.polyline().weight(3.0).points_colored(combined_plot);
+    let plot = |signal: Signal, vert_shift: f32, color: rgb::Srgb<u8>| {
+        let colored_pts = time_and_x.clone().map(|(time, x)| {
+            let amp = signal.at(time) + vert_shift;
+            (pt2(x, amp), color)
+        });
+        draw.polyline().weight(3.0).points_colored(colored_pts);
+    };
+    plot(sine, 0.0, BLUE);
+    plot(square, 250.0, WHITE);
+    plot(combined.scale(0.5), -250.0, GREEN);
     draw.to_frame(app, &frame).unwrap();
 }


### PR DESCRIPTION
noop change w.r.t. behavior of `cargo run`, tests should still  pass (see CI)

<img width="1019" alt="Screenshot 2021-12-22 at 22 58 41" src="https://user-images.githubusercontent.com/4691093/147264486-179c6963-d02e-4e32-8b2a-8fac4eb6e0bb.png">

use Arc for Signal closures

Reason:
- Managing the lifetimes of the closures got tricky
once I started to evolve main.rs' drawing logic
- I used `Arc` instead of `Rc` because later we will
likely want to send `Signal`s to other threads: this
came up when I was experimenting with `nannou_audio`

Other changes:
- I took this opportunity to reduce the number of closures we generate by storing information needed for `.phase()` and
`.scale()` outside the closure. This way we can do `wave.clone().scale(2.0).phase(1.5 * period)` without creating a new closure: instead we only increment the reference count.

> Hopefully this churn doesn't paint Rust in a poor light, just some initial growing pains as I understand closures beter.