### PR TITLE
add a release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+# copied from https://github.com/rust-build/rust-build.action/blob/8ce9b9c/README.md
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    name: release ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            archive: zip
+          - target: x86_64-unknown-linux-musl
+            archive: tar.gz tar.xz
+          - target: x86_64-apple-darwin
+            archive: zip
+    steps:
+      - uses: actions/checkout@master
+      - name: Compile and release
+        uses: rust-build/rust-build.action@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUSTTARGET: ${{ matrix.target }}
+          ARCHIVE_TYPES: ${{ matrix.archive }}
+

--- a/README.md
+++ b/README.md
@@ -17,15 +17,28 @@ ________________________________________________________________________________
 
 Rust translation of [paulcadman/analog](https://github.com/paulcadman/analog)
 
-## visualize and hear
+## visualize 🎧 and hear 👀
 
-`cargo run # headphone warning`
+If you have [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) installed,
+clone this repo and run from source with:
+
+`cargo run`
+
+Or download a release from ./releases, unarchive the file, then run it.
+
+> watch out: sound and movement
 
 ## build
 
-`cargo build`
+`cargo build # debug build`
+
+`cargo build --release`
 
 ## test
 
 `cargo test`
+
+## release
+
+We use GitHub releases and the workflow in .github/workflows/release.yaml
 


### PR DESCRIPTION
add a release workflow

Copied from
https://github.com/rust-build/rust-build.action/blob/8ce9b9c/README.md

Theoretically, after this is merged we should be able to go to
https://github.com/mheiber/analogue/actions and click the "release"
workflow to generate and upload binaries for Mac, Linux, and Windows.
