### PR TITLE
Adds a noise module and a RMS function for signals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,4 +106,3 @@ impl FrequencyHz {
         TimeSecs(1.0) / TimeSecs(self.0 as f64)
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate custom_derive;
 #[macro_use]
 extern crate newtype_derive;
 
+pub mod noise;
 pub mod standard_signals;
 
 custom_derive! {
@@ -106,10 +107,3 @@ impl FrequencyHz {
     }
 }
 
-pub fn sample(rate: FrequencyHz, s: Signal) -> impl Iterator<Item = f64> {
-    (0..).map(move |n: u32| {
-        let sample_period = rate.period();
-        let t = n as f64 * sample_period.0;
-        s.at(TimeSecs(t))
-    })
-}

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -10,6 +10,8 @@ pub fn sample(rate: FrequencyHz, s: Signal) -> impl Iterator<Item = f64> {
 
 /// Estimates the root mean square (RMS) of a signal over a period
 ///
+/// https://en.wikipedia.org/wiki/Root_mean_square
+///
 /// # Arguments
 ///
 /// * `s` - The `Signal` used to compute the RMS

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -7,3 +7,33 @@ pub fn sample(rate: FrequencyHz, s: Signal) -> impl Iterator<Item = f64> {
         s.at(TimeSecs(t))
     })
 }
+
+/// Estimates the root mean square (RMS) of a signal over a period
+///
+/// # Arguments
+///
+/// * `s` - The `Signal` used to compute the RMS
+/// * `period` - The period (starting at phase=0) over which the computation is made
+///
+pub fn rms(s: Signal, period: TimeSecs) -> f64 {
+    // The number of samples should depend on the period.
+    let samples = 100;
+    let rate = FrequencyHz(((samples as f64) / period.0) as u32);
+
+    // The fold function is derived from:
+    //
+    // let a_1, ... a_n be the items of the iterator.
+    //
+    // mean_n = (1/n) * \sum_{i=1}^n a_i
+    //        = (1/n) * ( (n - 1) * mean_{n - 1} + a_n )
+    //        = mean_{n - 1} + (a_n - mean_{n - 1}) / n
+    //
+    sample(rate, s)
+        .map(|x| x.powf(2.0))
+        .enumerate()
+        .take(samples)
+        .fold(0.0 as f64, |m, (n, x)| {
+            m + (x - m) / ((n as i32 + 1) as f64)
+        })
+        .sqrt()
+}

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,0 +1,9 @@
+use crate::{FrequencyHz, Signal, TimeSecs};
+
+pub fn sample(rate: FrequencyHz, s: Signal) -> impl Iterator<Item = f64> {
+    (0..).map(move |n: u32| {
+        let sample_period = rate.period();
+        let t = n as f64 * sample_period.0;
+        s.at(TimeSecs(t))
+    })
+}

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -26,8 +26,8 @@ pub fn rms(s: Signal, period: TimeSecs) -> f64 {
         .map(|x| x.powf(2.0))
         .enumerate()
         .take(samples)
-        .fold(0.0 as f64, |m, (n, x)| {
-            m + (x - m) / ((n as i32 + 1) as f64)
+        .fold(0.0 as f64, |running_mean, (n, a)| {
+            running_mean + (a - running_mean) / ((n as i32 + 1) as f64)
         })
         .sqrt()
 }

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -20,14 +20,6 @@ pub fn rms(s: Signal, period: TimeSecs) -> f64 {
     let samples = 100;
     let rate = FrequencyHz(((samples as f64) / period.0) as u32);
 
-    // The fold function is derived from:
-    //
-    // let a_1, ... a_n be the items of the iterator.
-    //
-    // mean_n = (1/n) * \sum_{i=1}^n a_i
-    //        = (1/n) * ( (n - 1) * mean_{n - 1} + a_n )
-    //        = mean_{n - 1} + (a_n - mean_{n - 1}) / n
-    //
     sample(rate, s)
         .map(|x| x.powf(2.0))
         .enumerate()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use analogue::{
-        noise::{sample, rms},
+        noise::{rms, sample},
         standard_signals::{sine_wave, square_wave},
         FrequencyHz, Signal, TimeSecs,
     };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use analogue::{
-        sample,
+        noise::sample,
         standard_signals::{sine_wave, square_wave},
         FrequencyHz, Signal, TimeSecs,
     };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,14 +20,31 @@ mod tests {
         }
     }
 
-    fn approx_eq(lhs: f64, rhs: f64) -> bool {
-        (lhs - rhs).abs() <= 1e-5
+    fn approx_eq(lhs: f64, rhs: f64, tolerance: f64) -> bool {
+        (lhs - rhs).abs() <= tolerance
     }
 
     macro_rules! prop_assert_approx_eq {
         ($actual:expr, $expected: expr) => {
+            prop_assert_approx_eq!($actual, $expected, 1e-5)
+        };
+        ($actual:expr, $expected: expr, $tolerance: expr) => {
             prop_assert!(
-                approx_eq($actual, $expected),
+                approx_eq($actual, $expected, $tolerance),
+                "expected {} ~= {}",
+                $actual,
+                $expected
+            )
+        };
+    }
+
+    macro_rules! assert_approx_eq {
+        ($actual:expr, $expected: expr) => {
+            assert_approx_eq!($actual, $expected, 1e-5)
+        };
+        ($actual:expr, $expected: expr, $tolerance: expr) => {
+            assert!(
+                approx_eq($actual, $expected, $tolerance),
                 "expected {} ~= {}",
                 $actual,
                 $expected


### PR DESCRIPTION
The RMS function is needed because I'd like the amount of noise to be specified using the signal to noise ratio - which requires the RMS.

The first commit just creates the noise module and moves sample to it as it's not used by main.

I also changed `approx_eq` to take a tolerance parameter. Thankfully the callsites of `prop_assert_approx_eq` do not have to change because macros allow overloading (so the two argument version of the macro keeps the same behaviour).

The third commit actually adds the RMS function. This samples the signal with an arbitrary number of 100 samples. The number of samples should really be a function of the input period but this is good enough for now.

