### PR TITLE
Fast forward, rewind, and gentleness

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,18 @@ pub struct Signal {
     mul_output: f64,
 }
 
+impl Default for Signal {
+    fn default() -> Self {
+        let f = Arc::new(|_| 0.0);
+        Self {
+            f,
+            mul_input: Default::default(),
+            add_input: Default::default(),
+            mul_output: Default::default(),
+        }
+    }
+}
+
 impl Debug for Signal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("signal").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,18 +234,27 @@ fn view_add_signal(app: &n::App, _model: &Model, frame: n::Frame) {
     draw.background().color(n::BLACK);
     draw.text(
         r#"
-        "Make a selection:
+        Make a selection:
         (1) add square wave
         (2) add sine wave
 
-        after that, experiment with keys:
-            h, j, k, and l
-            u and d
-            x and o
-            Hold Shift with another key
-            Hold Ctrl with another key
+        Then edit components of the light blue wave:
 
---Then press o to return to this menu--"#,
+            h and l: adjust phase
+
+            u and d: adjust phrequency
+
+            U and D: adjust amplitude
+
+            j and k: select component wave (yellow)
+
+            H, J, K, L: pan
+
+            o and x: add and remove
+
+            ctrl: gentle adjust
+
+--You can press o to return to this menu--"#,
     )
     .left_justify()
     .font_size(24)

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ struct Model {
     shift_key_is_down: bool,
     ctrl_key_is_down: bool,
     view_y: f32,
+    view_t: f32,
 }
 
 enum ModeKind {
@@ -73,6 +74,7 @@ impl Default for Model {
             ctrl_key_is_down: Default::default(),
             edit_state: Default::default(),
             view_y: Default::default(),
+            view_t: Default::default(),
         }
     }
 }
@@ -126,19 +128,21 @@ fn event(_app: &n::App, model: &mut Model, event: n::WindowEvent) {
     }
     let shift = &mut model.shift_key_is_down;
     let ctrl = &mut model.ctrl_key_is_down;
-    let gentle = if *ctrl { 0.1 } else { 1.0 };
+    let gentle: f64 = if *ctrl { 0.1 } else { 1.0 };
     match &model.mode_kind {
         ModeKind::Edit => match event {
+            KeyPressed(H) if *shift => model.view_t -= 30.0 * gentle as f32,
             KeyPressed(H) => model.phase(-0.2 * gentle),
+            KeyPressed(L) if *shift => model.view_t += 30.0 * gentle as f32,
             KeyPressed(L) => model.phase(0.2 * gentle),
             KeyPressed(U) if *shift => model.scale(1.0 + 0.25 * gentle),
             KeyPressed(D) if *shift => model.scale(1.0 / (1.0 + 0.25 * gentle)),
             KeyPressed(U) => model.incr_frequency(1.0 + 0.25 * gentle),
             KeyPressed(D) => model.incr_frequency(1.0 / (1.0 + 0.25 * gentle)),
 
-            KeyPressed(J) if *shift => model.view_y -= 10.0,
+            KeyPressed(J) if *shift => model.view_y -= 20.0 * gentle as f32,
             KeyPressed(J) => model.incr_selection(1),
-            KeyPressed(K) if *shift => model.view_y += 10.0,
+            KeyPressed(K) if *shift => model.view_y += 20.0 * gentle as f32,
             KeyPressed(K) => model.incr_selection(-1),
             KeyPressed(X) => model.remove_signal(),
             KeyPressed(O) => model.goto_add_mode(),
@@ -185,7 +189,7 @@ fn view(app: &n::App, model: &Model, frame: n::Frame) {
 }
 
 fn view_edit_signals(app: &n::App, model: &Model, frame: n::Frame) {
-    let t = TimeSecs(app.time as f64);
+    let t = TimeSecs((app.time + model.view_t) as f64);
     let selection = model.edit_state.selection;
     let scale = 100.0 + selection as f64 * 5.0;
     let combined = model.combined.scale(0.5);

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,20 +46,14 @@ fn model(app: &n::App) -> Model {
 
 impl Default for Model {
     fn default() -> Self {
-        let hz = FrequencyHz(1);
-        let signals = Vec::new();
-        let combined = Signal::sum(signals.clone());
-
-        let audio_host = audio::Host::new();
-
         let audio_model = AudioModel {
-            phase: 0.0,
-            hz: hz.0 as f64 * 440.0, // scaled to middle A for easy listening
-            combined: combined.clone(),
+            phase: Default::default(),
+            hz: 440.0, // scaled to middle A for easy listening
+            combined: Default::default(),
         };
 
         // can be used for pause, play, etc. All is silent when the stream is `drop`ped
-        let stream = audio_host
+        let stream = audio::Host::new()
             .new_output_stream(audio_model)
             .render(audio)
             .build()
@@ -67,8 +61,8 @@ impl Default for Model {
 
         Self {
             stream,
-            signals,
-            combined,
+            signals: Default::default(),
+            combined: Default::default(),
             mode_kind: ModeKind::AddSignal,
             shift_key_is_down: Default::default(),
             ctrl_key_is_down: Default::default(),


### PR DESCRIPTION
Several commits on this PR branch:
- refactors to use `Default::default()` more
- fast forward and rewind + the instructions page has actual instructions
- hold Ctrl for "gentle" adjustments
