### PR TITLE
Adds gaussian_white_noise and integrates this into the UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "nannou_audio",
  "newtype_derive",
  "proptest",
+ "rand 0.6.5",
 ]
 
 [[package]]
@@ -106,6 +107,12 @@ checksum = "cc4f1d82f164f838ae413296d1131aa6fa79b917d25bebaa7033d25620c09219"
 dependencies = [
  "libloading 0.7.2",
 ]
+
+[[package]]
+name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -244,6 +251,15 @@ dependencies = [
  "glob",
  "libc",
  "libloading 0.7.2",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -496,7 +512,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 0.1.10",
  "crossbeam-utils 0.7.2",
  "lazy_static",
@@ -534,7 +550,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -734,6 +750,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -989,7 +1011,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "hashbrown",
 ]
 
@@ -1231,7 +1253,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1240,7 +1262,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1279,7 +1301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1577,7 +1599,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-traits",
 ]
 
@@ -1587,7 +1609,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-integer",
  "num-traits",
 ]
@@ -1598,7 +1620,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-integer",
  "num-traits",
 ]
@@ -1609,7 +1631,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1892,6 +1914,25 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift 0.1.1",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -1917,6 +1958,16 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
@@ -1934,6 +1985,21 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1955,6 +2021,15 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
@@ -1969,6 +2044,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2020,7 +2148,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "crossbeam-deque 0.8.1",
  "either",
  "rayon-core",
@@ -2037,6 +2165,15 @@ dependencies = [
  "crossbeam-utils 0.8.5",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ custom_derive = "0.1.7"
 nannou = "0.18.1"
 nannou_audio = "0.18.0"
 newtype_derive = "0.1.6"
-
+rand = "0.6.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
-use analogue::noise::gaussian_white_noise;
-use analogue::{FrequencyHz, Signal, TimeSecs};
+use analogue::{noise::gaussian_white_noise, FrequencyHz, Signal, TimeSecs};
 mod standard_signals;
 use standard_signals::{sine_wave, square_wave};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use analogue::noise::gaussian_white_noise;
 use analogue::{FrequencyHz, Signal, TimeSecs};
 mod standard_signals;
 use standard_signals::{sine_wave, square_wave};
@@ -91,6 +92,12 @@ impl Model {
         let len = self.signals.len() as i32;
         self.edit_state.selection = (selection + amt).rem_euclid(len) as usize;
     }
+    fn add_white_noise(&mut self) {
+        let selection = self.edit_state.selection;
+        // Choice of 8.0 for signal to noise ratio is arbitrary aethetic judgment..
+        self.signals[selection] =
+            gaussian_white_noise(self.signals[selection].clone(), 8.0, TimeSecs(1.0));
+    }
     fn push_signal_and_goto_edit_mode(&mut self, signal: Signal) {
         self.signals.push(signal);
         self.mode_kind = ModeKind::Edit;
@@ -133,6 +140,7 @@ fn event(_app: &n::App, model: &mut Model, event: n::WindowEvent) {
             KeyPressed(D) if *shift => model.scale(1.0 / (1.0 + 0.25 * gentle)),
             KeyPressed(U) => model.incr_frequency(1.0 + 0.25 * gentle),
             KeyPressed(D) => model.incr_frequency(1.0 / (1.0 + 0.25 * gentle)),
+            KeyPressed(N) => model.add_white_noise(),
 
             KeyPressed(J) if *shift => model.view_y -= 20.0 * gentle as f32,
             KeyPressed(J) => model.incr_selection(1),
@@ -245,6 +253,8 @@ fn view_add_signal(app: &n::App, _model: &Model, frame: n::Frame) {
             u and d: adjust phrequency
 
             U and D: adjust amplitude
+
+            n: Add white noise
 
             j and k: select component wave (yellow)
 

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -2,7 +2,7 @@ use crate::{FrequencyHz, Signal, TimeSecs};
 use rand::distributions::{Distribution, Normal};
 use std::sync::Arc;
 
-pub fn sample(rate: FrequencyHz, s: Signal) -> impl Iterator<Item = f64> {
+pub fn sample<'s>(rate: FrequencyHz, s: &'s Signal) -> impl Iterator<Item = f64> + 's{
     (0..).map(move |n: u32| {
         let sample_period = rate.period();
         let t = n as f64 * sample_period.0;
@@ -19,7 +19,7 @@ pub fn sample(rate: FrequencyHz, s: Signal) -> impl Iterator<Item = f64> {
 /// * `s` - The `Signal` used to compute the RMS
 /// * `period` - The period (starting at phase=0) over which the computation is made
 ///
-pub fn rms(s: Signal, period: TimeSecs) -> f64 {
+pub fn rms(s: &Signal, period: TimeSecs) -> f64 {
     // The number of samples should depend on the period.
     let samples = 100;
     let rate = FrequencyHz(((samples as f64) / period.0) as u32);
@@ -45,7 +45,7 @@ pub fn rms(s: Signal, period: TimeSecs) -> f64 {
 /// * `signal_to_noise` - The desired signal to noise ratio for the returned signal.
 /// * `sample_duration` - A period to analyse the base Signal (should be around one period of the signal)
 pub fn gaussian_white_noise(s: Signal, signal_to_noise: f64, sample_duration: TimeSecs) -> Signal {
-    let rms_signal = rms(s.clone(), sample_duration);
+    let rms_signal = rms(&s, sample_duration);
     let rms_noise = (rms_signal.powf(2.0) / (10.0f64.powf(signal_to_noise / 10.0))).sqrt();
     let dist = Normal::new(0.0, rms_noise.powf(2.0));
     let noise = move |_| dist.sample(&mut rand::thread_rng());

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -2,7 +2,7 @@ use crate::{FrequencyHz, Signal, TimeSecs};
 use rand::distributions::{Distribution, Normal};
 use std::sync::Arc;
 
-pub fn sample<'s>(rate: FrequencyHz, s: &'s Signal) -> impl Iterator<Item = f64> + 's{
+pub fn sample<'s>(rate: FrequencyHz, s: &'s Signal) -> impl Iterator<Item = f64> + 's {
     (0..).map(move |n: u32| {
         let sample_period = rate.period();
         let t = n as f64 * sample_period.0;

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -46,8 +46,8 @@ pub fn rms(s: &Signal, period: TimeSecs) -> f64 {
 /// * `sample_duration` - A period to analyse the base Signal (should be around one period of the signal)
 pub fn gaussian_white_noise(s: Signal, signal_to_noise: f64, sample_duration: TimeSecs) -> Signal {
     let rms_signal = rms(&s, sample_duration);
-    let rms_noise = (rms_signal.powf(2.0) / (10.0f64.powf(signal_to_noise / 10.0))).sqrt();
-    let dist = Normal::new(0.0, rms_noise.powf(2.0));
+    let rms_noise_squared = rms_signal.powf(2.0) / (10.0f64.powf(signal_to_noise / 10.0));
+    let dist = Normal::new(0.0, rms_noise_squared);
     let noise = move |_| dist.sample(&mut rand::thread_rng());
     let noise_signal = Signal::new(Arc::new(noise));
     s.clone() + noise_signal

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -63,7 +63,7 @@ mod tests {
     fn rms_sine_wave() {
         let expected_rms = 0.5f64.sqrt();
         for f in (1..100).map(FrequencyHz) {
-            assert_approx_eq!(rms(sine_wave(f), f.period()), expected_rms, 1e-3);
+            assert_approx_eq!(rms(&sine_wave(f), f.period()), expected_rms, 1e-3);
         }
     }
 
@@ -100,14 +100,14 @@ mod tests {
 
         #[test]
         fn abs_sample_sine_lt_1(rate in arb_frequency(), freq in arb_frequency()) {
-            for v in sample(rate, sine_wave(freq)).take(100) {
+            for v in sample(rate, &sine_wave(freq)).take(100) {
                 prop_assert!(v.abs() <= 1.0);
             }
         }
 
         #[test]
         fn sample_square_1_or_neg_1(rate in arb_frequency(), freq in arb_frequency()) {
-            for v in sample(rate, square_wave(freq)).take(100) {
+            for v in sample(rate, &square_wave(freq)).take(100) {
                 prop_assert!(v.abs() == 1.0);
             }
         }
@@ -123,7 +123,7 @@ mod tests {
             prop_assume!(phase >= 0.0);
             let wave = sine_wave(f).phase(1.0);
             let expected = wave.at(TimeSecs(0.0));
-            for v in sample(f, wave).take(10) {
+            for v in sample(f, &wave).take(10) {
                 prop_assert_approx_eq!(v, expected);
             }
         }
@@ -132,7 +132,7 @@ mod tests {
         fn rms_square_wave(f in arb_frequency(), p in arb_timesecs()) {
             prop_assume!(f > FrequencyHz(0));
             prop_assume!(p > TimeSecs(0.0));
-            prop_assert_approx_eq!(rms(square_wave(f), p), 1.0);
+            prop_assert_approx_eq!(rms(&square_wave(f), p), 1.0);
         }
     }
 }


### PR DESCRIPTION
<img width="1030" alt="Screenshot 2021-12-25 at 21 04 40" src="https://user-images.githubusercontent.com/92877/147394120-2ec4c14f-5171-4687-9471-d8347eb60055.png">

Adds `gaussian_white_noise` which adds noise to a Signal using the [Additive white Gaussian noise](https://en.wikipedia.org/wiki/Additive_white_Gaussian_noise) model.

The noise can be tuned using the `signal_to_noise` parameter.

I've added this to the UI under the `n` key. I had a play around with different values and decided that a `signal_to_noise` value of `8.0` looked OK, so it's hardcoded to that at the moment.