### PR TITLE
Less syntax noise

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,17 +74,17 @@ impl Default for Model {
 }
 
 impl Model {
+    fn selected(&mut self) -> &mut Signal {
+        &mut self.signals[self.edit_state.selection]
+    }
     fn phase(&mut self, amt: f64) {
-        let selection = self.edit_state.selection;
-        self.signals[selection] = self.signals[selection].phase(amt);
+        self.selected().phase(amt);
     }
     fn scale(&mut self, amt: f64) {
-        let selection = self.edit_state.selection;
-        self.signals[selection] = self.signals[selection].scale(amt);
+        self.selected().scale(amt);
     }
     fn incr_frequency(&mut self, amt: f64) {
-        let selection = self.edit_state.selection;
-        self.signals[selection] = self.signals[selection].incr_frequency(amt);
+        self.selected().incr_frequency(amt);
     }
     fn incr_selection(&mut self, amt: i32) {
         let selection = self.edit_state.selection as i32;
@@ -192,13 +192,14 @@ fn view(app: &n::App, model: &Model, frame: n::Frame) {
 fn view_edit_signals(app: &n::App, model: &Model, frame: n::Frame) {
     let t = TimeSecs((app.time + model.view_t) as f64);
     let selection = model.edit_state.selection;
+    let mut combined = model.combined.clone();
+    combined.scale(0.5);
+    let mut signals = model.signals.clone();
+    signals.push(combined);
     let scale = 100.0 + selection as f64 * 5.0;
-    let combined = model.combined.scale(0.5);
-    let signals = model
-        .signals
-        .iter()
-        .chain(std::iter::once(&combined))
-        .map(|s| s.scale(scale));
+    for s in &mut signals {
+        s.scale(scale)
+    }
 
     let win = app.window_rect();
     let draw = app.draw();

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,6 +1,5 @@
 use crate::{FrequencyHz, Signal, TimeSecs};
 use rand::distributions::{Distribution, Normal};
-use std::sync::Arc;
 
 pub fn sample<'s>(rate: FrequencyHz, s: &'s Signal) -> impl Iterator<Item = f64> + 's {
     (0..).map(move |n: u32| {
@@ -49,6 +48,6 @@ pub fn gaussian_white_noise(s: Signal, signal_to_noise: f64, sample_duration: Ti
     let rms_noise_squared = rms_signal.powf(2.0) / (10.0f64.powf(signal_to_noise / 10.0));
     let dist = Normal::new(0.0, rms_noise_squared);
     let noise = move |_| dist.sample(&mut rand::thread_rng());
-    let noise_signal = Signal::new(Arc::new(noise));
+    let noise_signal = Signal::new(noise);
     s.clone() + noise_signal
 }

--- a/src/standard_signals.rs
+++ b/src/standard_signals.rs
@@ -1,10 +1,9 @@
 use crate::{FrequencyHz, Signal, TimeSecs};
 use std::f64::consts::PI;
-use std::sync::Arc;
 
 pub fn sine_wave(freq: FrequencyHz) -> Signal {
     let f = move |t| (2.0 * PI * freq.at(t)).sin();
-    Signal::new(Arc::new(f))
+    Signal::new(f)
 }
 
 pub fn square_wave(freq: FrequencyHz) -> Signal {
@@ -16,5 +15,5 @@ pub fn square_wave(freq: FrequencyHz) -> Signal {
             1.0
         }
     };
-    Signal::new(Arc::new(f))
+    Signal::new(f)
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,7 +6,7 @@ mod tests {
         FrequencyHz, Signal, TimeSecs,
     };
     use proptest::prelude::*;
-    use std::sync::Arc;
+
     prop_compose! {
         fn arb_frequency()(n in any::<u32>()) -> FrequencyHz {
             FrequencyHz(n)
@@ -22,7 +22,7 @@ mod tests {
     prop_compose! {
         fn arb_signal()(amplitude in any::<f64>()) -> Signal {
             let f = move |_| amplitude;
-            Signal::new(Arc::new(f))
+            Signal::new(f)
         }
     }
 
@@ -88,7 +88,9 @@ mod tests {
         fn test_sine_phase_and_scale(freq in arb_frequency()) {
             prop_assume!(freq > FrequencyHz(0));
             let t = freq.period() * TimeSecs(0.25);
-            let signal = sine_wave(freq).scale(2.0).phase(2.0 * t.0);
+            let mut signal = sine_wave(freq);
+            signal.scale(2.0);
+            signal.phase(2.0 * t.0);
             prop_assert_approx_eq!(signal.at(t), -2.0);
         }
         #[test]
@@ -121,7 +123,8 @@ mod tests {
         fn sample_sine_phase_is_periodic(f in arb_frequency(), phase in any::<f64>()) {
             prop_assume!(f > FrequencyHz(0));
             prop_assume!(phase >= 0.0);
-            let wave = sine_wave(f).phase(1.0);
+            let mut wave = sine_wave(f);
+            wave.phase(1.0);
             let expected = wave.at(TimeSecs(0.0));
             for v in sample(f, &wave).take(10) {
                 prop_assert_approx_eq!(v, expected);


### PR DESCRIPTION
Less cloning, less explicit Arc-ing

No visible change in behavior.

I wanted to try biting the bullet and
embracing Rust's mutability-with-guardrails.
So we avoid cloning by having .phase, .scale, etc.
mutate self. It's actually kinda nice because
Rust forces exlusive mutable access.

The other change, avodiing explicit `Arc::new`s
everywhere, lowers noise and makes it easier for us
to change the representation.
