### PR TITLE
Use 'use' instead of 'extern crate'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
+use custom_derive::custom_derive;
+use newtype_derive::*;
 use std::fmt::Debug;
 use std::sync::Arc;
-#[macro_use]
-extern crate custom_derive;
-#[macro_use]
-extern crate newtype_derive;
 
 pub mod noise;
 pub mod standard_signals;


### PR DESCRIPTION
apparently "extern crate" is almost never needed as of Rust 2018:
https://stackoverflow.com/questions/64623568/why-sometimes-extern-crate-is-needed

Iuc "extern" is still part of the language, but it can be
specified either in code or in command-line flags to rustc (`--extern
$CRATE_NAME`)
And it seems that Cargo now generates these flags for us:

https://github.com/rust-lang/cargo/blob/fcef61230c3b6213b6b0d233a36ba4ebd1649ec3/src/cargo/core/compiler/mod.rs#L1150